### PR TITLE
fix: separate package.json for root-level test and frontend environme…

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Healthchecks ensure that the backend only starts when the DB is ready.
 │   │   └── main.tsx
 │   ├── Dockerfile
 │   ├── index.html
+│   ├── package.json
 │   ├── tsconfig.json
 │   └── vite.config.ts
 │──.env

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,7 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 
 # Copy package manifests
-COPY package.json ./
+COPY frontend/package.json ./
 
 # Install dependencies
 # May be RUN npm ci for exact dependencies based on package-lock.json!

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "f1-dashboard",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.8",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.3",
+    "typescript": "^5.4.3",
+    "vite": "^7.0.0"
+  }
+}


### PR DESCRIPTION
Separated concerns between root and frontend environments by creating two distinct package.json files:
frontend/package.json for React app and Vite
Root-level package.json for test tools and potential shared scripts
This resolves previous Docker build and path conflicts
Ensures each context has a clean and self-contained environment